### PR TITLE
Allow to return cursor result on custom ordered queries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes History
 
+1.0.9
+-----
+Add cursor result response with custom ordered query
+
 1.0.8
 -----
 Fix cursor pagination with joined queries

--- a/src/Repositories/Base/Repository.php
+++ b/src/Repositories/Base/Repository.php
@@ -2,14 +2,16 @@
 
 namespace Saritasa\Repositories\Base;
 
-use Saritasa\Exceptions\RepositoryException;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
-use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Saritasa\DingoApi\Paging\CursorRequest;
 use Saritasa\DingoApi\Paging\CursorResult;
 use Saritasa\DingoApi\Paging\CursorResultAuto;
 use Saritasa\DingoApi\Paging\PagingInfo;
+use Saritasa\Exceptions\RepositoryException;
 
 /**
  * Superclass for any repository.
@@ -157,6 +159,34 @@ class Repository implements IRepository
         return $this->toCursorResult($cursor, $this->query()->where($fieldValues));
     }
 
+    /**
+     * Wrap the query to support cursor pagination with custom sort.
+     * @param CursorRequest $cursor Requested cursor parameters
+     * @param \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder $originalQuery
+     * @return CursorResult
+     */
+    protected function toCursorResultWithCustomSort(CursorRequest $cursor, $originalQuery)
+    {
+        $originalQuery->crossJoin(DB::raw('(SELECT @row := 1) as r'));
+        $idKey = CursorResultAuto::ROW_NUM_COLUMN;
+        $wrappedQuery = DB::table(
+            DB::raw("(SELECT *, (@row := @row+1) as {$idKey} FROM (" . $originalQuery->toSql() . ") as t1) as t2")
+        )->mergeBindings(($originalQuery instanceof Builder) ? $originalQuery : $originalQuery->getQuery());
+
+        /** @var Model $fakeModel */
+        $originalClass = get_class($this->model);
+        $fakeModel = new $originalClass();
+        $fakeModel->setKeyName($idKey);
+        $fakeModel->setTable(DB::raw("(" . $wrappedQuery->toSql() . ") AS " . $this->model->getTable()));
+        $items = $fakeModel->newQuery()
+            ->mergeBindings($wrappedQuery)
+            ->where($idKey, '>', $cursor->current)
+            ->take($cursor->pageSize)
+            ->get();
+
+        return new CursorResultAuto($cursor, $items);
+    }
+    
     /**
      * @param CursorRequest $cursor Requested cursor parameters
      * @param \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder $query


### PR DESCRIPTION
Wrap query by query with row number column. Result query items has same class as repository model class to pass 'instanceof' validations.