### PR TITLE
Add ability to join related tables by reilation name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,12 +1,16 @@
 # Changes History
 
+1.0.16
+------
+Add support for repositories to join tables by relation name
+
 1.0.15
 ------
 Explicitly add [saritasa/dingo-api-custom](https://github.com/Saritasa/php-dingo-api-custom) as dependency
 
 1.0.14
 -----
-Make Reposiotory query() method overridable (protected)
+Make Repository query() method overridable (protected)
 
 1.0.13
 ------
@@ -42,7 +46,7 @@ Improved cursor pagination
 
 1.0.5
 -----
-- Weeker typing requiredments for paging
+- Weaker typing requirements for paging
 - Remove clones of BaseApiController
 - Implement cursor pagination as in Fractal samples
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,38 @@ $ composer require saritasa/laravel-repositories
 ### IRepository
 Interface, declaring common methods
 
+### Repository
+Repository class implements **IRepository** interface. Contains helper methods to build query for SQL-like storages.
+Has protected method to join tables by Eloquent model relation name.
+Supported relations are: **BelongsToMany**, **HasOne**, **HasMany**, **BelongsTo**
+Nested relations supported.
+
+**Example**
+
+For method
+
+```php
+public function getUsersList(): Collection
+{
+    $query = $this->query();
+
+    $this->joinRelation($query, ['role', 'profile', 'cars', 'profile.phones']);
+
+    return $query;
+}
+```
+
+result query will be
+
+```SQL
+SELECT *
+FROM "users"
+  LEFT JOIN "roles" ON "users"."role_id" = "roles"."id"
+  LEFT JOIN "profiles" ON "profiles"."user_id" = "users"."id"
+  LEFT JOIN "cars" ON "cars"."user_id" = "users"."id"
+  LEFT JOIN "phones" ON "phones"."profile_id" = "profiles"."id"
+```
+
 ## Exceptions
 ### Repository Exception
 Should be thrown by class, implementing IRepository, if there is no more suitable exception defined.

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "illuminate/database": "5.*",
         "league/fractal": "^0.16",
         "saritasa/dingo-api-custom": "^1.0",
+        "saritasa/php-common": "^1.0",
         "saritasa/laravel-controllers": "^2.0"
     },
     "require-dev": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,7 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="test/bootstrap.php"
+         bootstrap="vendor/autoload.php"
 >
   <testsuites>
     <testsuite name="Saritasa Repositories Test Suite">

--- a/tests/JoinRelationTest.php
+++ b/tests/JoinRelationTest.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace Saritasa\Repositories\Base;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\RelationNotFoundException;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\SQLiteConnection;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Saritasa\Exceptions\NotImplementedException;
+
+/**
+ * Check string rules
+ */
+class JoinRelationTest extends TestCase
+{
+    /** @var EntitiesRepository */
+    private $repository;
+
+    /**
+     * @param string|null $name
+     * @param array $data
+     * @param string $dataName
+     *
+     * @throws \Saritasa\Exceptions\RepositoryException
+     */
+    public function __construct(string $name = null, array $data = [], string $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+        $this->repository = new EntitiesRepository();
+    }
+
+    /**
+     * Test base query retrieving.
+     */
+    public function testBaseQuery()
+    {
+        $expectedSql = User::query()->toSql();
+        $simpleSql = strtolower($this->repository->getBaseQueryString());
+
+        self::assertEquals($simpleSql, $expectedSql);
+    }
+
+    /**
+     * Test BelongsTo relation joining.
+     */
+    public function testBelongsToJoin()
+    {
+        $actualSql = strtolower($this->repository->getQueryStringWithJoin('role'));
+        $expectedSql = User::query()->leftJoin('roles', 'users.role_id', '=', 'roles.id')->toSql();
+
+        self::assertEquals($expectedSql, $actualSql);
+    }
+
+    /**
+     * Test HasMany relation joining.
+     */
+    public function testHasManyJoin()
+    {
+        $actualSql = strtolower($this->repository->getQueryStringWithJoin('cars'));
+        $expectedSql = User::query()->leftJoin('cars', 'cars.user_id', '=', 'users.id')->toSql();
+
+        self::assertEquals($expectedSql, $actualSql);
+    }
+
+    /**
+     * Test HasOne relation joining.
+     */
+    public function testHasOneJoin()
+    {
+        $actualSql = strtolower($this->repository->getQueryStringWithJoin('profile'));
+        $expectedSql = User::query()->leftJoin('profiles', 'profiles.user_id', '=', 'users.id')->toSql();
+
+        self::assertEquals($expectedSql, $actualSql);
+    }
+
+    /**
+     * Test HasManyThrough relation joining.
+     */
+    public function testHasManyThroughJoin()
+    {
+        $actualSql = strtolower($this->repository->getQueryStringWithJoin('supervisors'));
+        $expectedSql = User::query()
+            ->leftJoin('supervisors_users', 'supervisors_users.user_id', '=', 'users.id')
+            ->leftJoin('supervisors', 'supervisors_users.supervisor_id', '=', 'supervisors.id')
+            ->toSql();
+
+        self::assertEquals($expectedSql, $actualSql);
+    }
+
+    /**
+     * Test joining relations of relations.
+     */
+    public function testNestedRelationsJoin()
+    {
+        $actualSql = strtolower($this->repository->getQueryStringWithJoin('profile.phones'));
+        $expectedSql = User::query()
+            ->leftJoin('profiles', 'profiles.user_id', '=', 'users.id')
+            ->leftJoin('phones', 'phones.profile_id', '=', 'profiles.id')
+            ->toSql();
+
+        self::assertEquals($expectedSql, $actualSql);
+    }
+
+    /**
+     * Test of multiple relations joining.
+     */
+    public function testMultipleRelationsJoin()
+    {
+        $actualSql = strtolower($this->repository->getQueryStringWithJoin(['profile', 'cars']));
+        $expectedSql = User::query()
+            ->leftJoin('profiles', 'profiles.user_id', '=', 'users.id')
+            ->leftJoin('cars', 'cars.user_id', '=', 'users.id')
+            ->toSql();
+
+        self::assertEquals($expectedSql, $actualSql);
+    }
+
+    /**
+     * Test that same relation joined only once.
+     */
+    public function testSingleJoin()
+    {
+        $actualSql = strtolower($this->repository->getQueryStringWithJoin(['profile.phones', 'profile']));
+        $expectedSql = User::query()
+            ->leftJoin('profiles', 'profiles.user_id', '=', 'users.id')
+            ->leftJoin('phones', 'phones.profile_id', '=', 'profiles.id')
+            ->toSql();
+
+        self::assertEquals($expectedSql, $actualSql);
+
+        $actualSql = strtolower($this->repository->getQueryStringWithJoin(['profile', 'profile.phones']));
+        $expectedSql = User::query()
+            ->leftJoin('profiles', 'profiles.user_id', '=', 'users.id')
+            ->leftJoin('phones', 'phones.profile_id', '=', 'profiles.id')
+            ->toSql();
+
+        self::assertEquals($expectedSql, $actualSql);
+    }
+
+    /**
+     * Test that unsupported relations types are throws valid exception.
+     */
+    public function testUnsupportedJoin()
+    {
+        self::expectException(NotImplementedException::class);
+        // Try to join polymorphic relation
+        $this->repository->getQueryStringWithJoin('notes');
+    }
+
+    /**
+     * Not declared in model relation method throws exception.
+     */
+    public function testUnknownJoin()
+    {
+        self::expectException(RelationNotFoundException::class);
+        $this->repository->getQueryStringWithJoin('potato');
+    }
+}
+
+/**
+ * Model class with fake connection generation.
+ */
+class InMemoryModel extends Model
+{
+    public function getConnection()
+    {
+        $pdo = new PDO('sqlite::memory:');
+
+        return new SQLiteConnection($pdo);
+    }
+}
+
+/**
+ * Fake user model class. Used to build test repository and perform tests on this model.
+ */
+class User extends InMemoryModel
+{
+    public function role(): BelongsTo
+    {
+        return $this->belongsTo(Role::class);
+    }
+
+    public function supervisors(): BelongsToMany
+    {
+        return $this->belongsToMany(Supervisor::class, 'supervisors_users');
+    }
+
+    public function cars(): HasMany
+    {
+        return $this->hasMany(Car::class);
+    }
+
+    public function profile(): HasOne
+    {
+        return $this->hasOne(Profile::class);
+    }
+
+    public function notes(): MorphMany
+    {
+        return $this->morphMany(Note::class, 'noteable');
+    }
+}
+
+/**
+ * User role model.
+ */
+class Role extends InMemoryModel
+{
+}
+
+/**
+ * Car that can be owned by user.
+ */
+class Car extends InMemoryModel
+{
+}
+
+/**
+ * User personal information profile.
+ */
+class Profile extends InMemoryModel
+{
+    public function phones(): HasMany
+    {
+        return $this->hasMany(Phone::class);
+    }
+}
+
+/**
+ * Supervisors that can supervise users.
+ */
+class Supervisor extends InMemoryModel
+{
+}
+
+/**
+ * Phone records that profile can contain.
+ */
+class Phone extends InMemoryModel
+{
+}
+
+/**
+ * Text note that can be applied for any model.
+ */
+class Note extends InMemoryModel
+{
+}
+
+/**
+ * Fake user records repository class. Has debug methods for performing tests.
+ */
+class EntitiesRepository extends Repository
+{
+    protected $modelClass = User::class;
+
+    /**
+     * Base query string. Used for testing SQL string retrieving.
+     *
+     * @return string
+     */
+    public function getBaseQueryString()
+    {
+        return $this->query()->toSql();
+    }
+
+    /**
+     * Helper method for retrieving result string of joined relation query.
+     *
+     * @param string|array $relations Relation name or array with relations names that should be joined
+     *
+     * @return string
+     * @throws NotImplementedException
+     */
+    public function getQueryStringWithJoin($relations): string
+    {
+        $query = $this->query();
+
+        $this->joinRelation($query, $relations);
+
+        return $query->toSql();
+    }
+}

--- a/tests/UnitTest.php
+++ b/tests/UnitTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Saritasa\Repositories\Base;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Check that unit tests configured and can be run.
+ */
+class UnitTest extends TestCase
+{
+    /**
+     * Simple test to check that unit tests working.
+     */
+    public function testUnitTestAvailable()
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
Please, see [readme](https://github.com/VladimirBerdnik/php-laravel-repositories/blob/f759f54c3810119e7619f06d01acfb48af5a3382/README.md#repository) for details.

Usage:
$this->joinRelation($query, ['role', 'profile', 'cars', 'profile.phones']);