### PR TITLE
Fix issue with using criterion with Carbon in case when key is field …

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Changes History
 
+3.2.1
+------
++ Methods getWith/findWhere/getWhere call when as value uses Carbon\Carbon instance and as key field name, now not throws BadCriteriaException.
+
+3.2.0
+------
++ Now in repository methods getWith/getWhere/findWhere could be passed
+instance of Criterion instead array.
++ Available use multiple in and not in operators in any nested level
++ Carbon instance can be passed to compare as date
++ In case of bad query state BadCriteriaException will be thrown
+
 3.1.0
 ------
 + Add package configuration file.

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -392,7 +392,9 @@ class Repository implements IRepository
         $subQuery = $builder->forNestedWhere();
         foreach ($criteria as $key => $criterionData) {
             switch (true) {
-                case is_string($key) && (!is_array($criterionData) && !is_object($criterionData)):
+                case is_string($key)
+                    && ((!is_array($criterionData) && !is_object($criterionData))
+                        || $criterionData instanceof Carbon):
                     $criterion = new Criterion([Criterion::ATTRIBUTE => $key, Criterion::VALUE => $criterionData]);
                     break;
                 case $criterionData instanceof Criterion:


### PR DESCRIPTION
## Fixed:
- Methods getWith/findWhere/getWhere call when as value uses Carbon\Carbon instance and as key field name, now not throws BadCriteriaException.

Example: 
```php
$repository->findWhere(['date' => Carbon::today()]);
```