### PR TITLE
Add comparing carbon date as timestamp instead date #11

### DIFF
--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -420,15 +420,6 @@ class Repository implements IRepository
                     $subQuery->whereNotIn($criterion->attribute, $criterion->value, $criterion->boolean);
                     break;
                 default:
-                    if ($criterion->value instanceof Carbon) {
-                        $subQuery->whereDate(
-                            $criterion->attribute,
-                            $criterion->operator,
-                            $criterion->value,
-                            $criterion->boolean
-                        );
-                        break;
-                    }
                     $subQuery->where(
                         $criterion->attribute,
                         $criterion->operator,


### PR DESCRIPTION
Now all filters have behavior like default `where` conditions in Eloquent.
Fixes #11 